### PR TITLE
Resolves #11 - Camera preview is stopped when broadcast is stopped on Android.

### DIFF
--- a/android/src/main/java/com/rngocoder/BroadcastView.java
+++ b/android/src/main/java/com/rngocoder/BroadcastView.java
@@ -171,6 +171,7 @@ public class BroadcastView extends FrameLayout implements LifecycleEventListener
     public boolean isBroadcasting() {
         return broadcasting;
     }
+    
 
     public void setBroadcasting(boolean broadcasting) {
         if(goCoder == null){
@@ -211,7 +212,6 @@ public class BroadcastView extends FrameLayout implements LifecycleEventListener
                         broadcast.putString("broadcastName", getBroadcastName());
                         broadcast.putString("status", "stopped");
                         event.putMap("event", broadcast);
-                        stopCamera();
                         mEventEmitter.receiveEvent(getId(), Events.EVENT_BROADCAST_STOP.toString(), event);
                     }
                 }


### PR DESCRIPTION
Resolves #11 

Removed the `stopCamera` call from `setBroadcasting`. This allows the camera preview to continue running once the broadcast is stopped on Android. This makes the behavior consistent with what is present in iOS and allows instances where a GoCoder component is re-used for multiple broadcasts.

**Note:** The `stopCamera` method is still called appropriately in the `onHostDestroy` method as far as I can tell.