### PR TITLE
Adds the ability for broadcast name/stream name to be changed changed

### DIFF
--- a/android/src/main/java/com/rngocoder/BroadcastManager.java
+++ b/android/src/main/java/com/rngocoder/BroadcastManager.java
@@ -68,6 +68,11 @@ public class BroadcastManager {
             mGoCoder.unmuteAudio();
         }
     }
+    public static void changeStreamName(WowzaGoCoder mGoCoder, String broadcastName){
+        WowzaConfig broadcastConfig = mGoCoder.getConfig();
+        broadcastConfig.setStreamName(broadcastName);
+        mGoCoder.setConfig(broadcastConfig);
+    }
 
     private static WZMediaConfig getSizePresetWithInt(int sizePreset){
         switch (sizePreset){

--- a/android/src/main/java/com/rngocoder/BroadcastView.java
+++ b/android/src/main/java/com/rngocoder/BroadcastView.java
@@ -142,6 +142,7 @@ public class BroadcastView extends FrameLayout implements LifecycleEventListener
 
     public void setBroadcastName(String broadcastName) {
         this.broadcastName = broadcastName;
+        BroadcastManager.changeStreamName(goCoder, this.broadcastName);
     }
 
     public int getSizePreset() {

--- a/android/src/main/java/com/rngocoder/BroadcastView.java
+++ b/android/src/main/java/com/rngocoder/BroadcastView.java
@@ -142,7 +142,10 @@ public class BroadcastView extends FrameLayout implements LifecycleEventListener
 
     public void setBroadcastName(String broadcastName) {
         this.broadcastName = broadcastName;
-        BroadcastManager.changeStreamName(goCoder, this.broadcastName);
+
+        if (goCoder != null) {
+            BroadcastManager.changeStreamName(goCoder, this.broadcastName);
+        }
     }
 
     public int getSizePreset() {

--- a/ios/BroadcastManager.h
+++ b/ios/BroadcastManager.h
@@ -38,4 +38,5 @@ static NSString *didStopBroadcast                 = @"onBroadcastStop";
 
 +(void)releaseBroadcast:(WMBroadcastView *) broadcast;
 +(void)changeFrame:(CGRect)frame andBroadcastView:(WMBroadcastView *) broadcast;
++(void)changeStreamName:(NSString *)name andBroadcastView:(WMBroadcastView *)broadcast;
 @end

--- a/ios/BroadcastManager.m
+++ b/ios/BroadcastManager.m
@@ -94,5 +94,8 @@ static BroadcastManager *sharedMyManager = nil;
         [broadcast updateBroadcastViewPosition:frame];
     });
 }
++(void)changeStreamName:(NSString *)name andBroadcastView:(WMBroadcastView *)broadcast {
+    [broadcast setStreamName:name];
+}
 
 @end

--- a/ios/RNBroadcastView.m
+++ b/ios/RNBroadcastView.m
@@ -145,6 +145,10 @@
     [BroadcastManager invertCamera:self.broadcast];
     _frontCamera = frontCamera;
 }
+-(void)setBroadcastName:(NSString *)broadcastName{
+    [BroadcastManager changeStreamName:broadcastName andBroadcastView:self.broadcast];
+    _broadcastName = broadcastName;
+}
 #pragma mark - WMBroadcastViewDelegate Methods
 
 -(void)didStartBroacast{

--- a/ios/WMBroadcastView.h
+++ b/ios/WMBroadcastView.h
@@ -26,5 +26,6 @@ typedef void (^completionBlock)(NSError *error);
 -(void)setFlashState:(BOOL)state;
 -(NSUInteger)invertCamera;
 -(void)closeBroadcast;
+-(void)setStreamName:(NSString*)name;
 
 @end

--- a/ios/WMBroadcastView.m
+++ b/ios/WMBroadcastView.m
@@ -108,6 +108,9 @@ NSString * const BlackAndWhiteKey = @"BlackAndWhiteKey";
 -(void)setFlashState:(BOOL)state{
     self.goCoder.cameraPreview.camera.torchOn = state;
 }
+-(void)setStreamName:(NSString*)name{
+    self.goCoder.config.streamName = name;
+}
 -(NSUInteger)invertCamera{
     WZCamera *otherCamera = [self.goCoderCameraPreview otherCamera];
     if (![otherCamera supportsWidth:self.wozwaConfig.videoWidth]) {


### PR DESCRIPTION
The GoCoder broadcast name is currently set one time on initialization. For certain use cases, it is valuable to be able to change this value post-render, such as in the case where you are re-using a single GoCoder component for multiple different broadcasts.

This pull request handles changes of the `broadcastName` property and updates the GoCoder instance accordingly.